### PR TITLE
Add pio.h and all build folders to the ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 *.csv
 *.xml
 fp-info-cache
+*.pio.h
 
-PMod_CC1101/Software/build
+build/


### PR DESCRIPTION
Improvments to git handling:
-To prevent the *.pio.h files generated as part of the build being added to the git project
-To prevent the build folder generated being added to the repo 